### PR TITLE
redo the regex in jsongen

### DIFF
--- a/plugins/jsongen.js
+++ b/plugins/jsongen.js
@@ -1,6 +1,8 @@
 
 module.exports = function (markdownstr) {
-  const regex = /^### (.*\?)\n+((?:(?!\n##)[\s\S])*)/gm
+  const regex = /^### (.+?\n+)([^#]+)/gm
+  //^### for markdown header, group1 is the question and any number of newlines
+  //group2 is the answer, defined by "anything, incl whitespace, that isn't a #"
 
   const output = []
   let match


### PR DESCRIPTION
# Description

Fixes the regex in `jsongen.js` so that all questions and answers show up in UNCLE's command repository.

# The Problem

The regex in `jsongen.js` is used to generate `lancer-faq.netlify.app/faq.json`, which is where UNCLEBot's `::faq` command pulls data from. This regex wasn't picking up every question, so as a result, entries could be added to `index.md` but not added to UNCLE's library of questions. 

See below for examples:

![firefox_2021_05_11_18-32-52-330](https://user-images.githubusercontent.com/23746623/117897537-ab0d3d00-b288-11eb-87a8-27d041614237.png)

![firefox_2021_05_11_18-34-20-167](https://user-images.githubusercontent.com/23746623/117897544-b06a8780-b288-11eb-9b43-d6d5c7c60add.png)

# The Fix

The issue was that the previous regex demanded that questions end in a question mark. This new regex relaxes that restriction. See below:

![firefox_2021_05_11_18-33-23-122](https://user-images.githubusercontent.com/23746623/117897598-c2e4c100-b288-11eb-978b-161c825ca4f8.png)

![firefox_2021_05_11_18-34-32-291](https://user-images.githubusercontent.com/23746623/117897603-c5dfb180-b288-11eb-97fe-06d21fc7dc60.png)

Note that with the new regex, all 70 questions are picked up (as indicated by the "70 matches" in the top right corner). (You can check this yourself by CTRL+F how many `###` strings show up in `index.md`

# Rollback plan

If this fails what I can do is create a revert commit, go thru the same pull request process and merge it into lancer-faq. I don't have access to the lancer-faq heroku dashboard, unfortunately, so I can't revert it myself.
